### PR TITLE
Upgrade projects to LTS versions of .NET

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: 1.0.{build}
 
 # Build worker image
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true

--- a/src/Collections/Collections.csproj
+++ b/src/Collections/Collections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>AEGIS.Collections</RootNamespace>
     <AssemblyName>AEGIS.Collections</AssemblyName>
     <Version>0.1.0</Version>

--- a/src/Core.Reference/Core.Reference.csproj
+++ b/src/Core.Reference/Core.Reference.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>AEGIS.Reference</RootNamespace>
     <AssemblyName>AEGIS.Core.Reference</AssemblyName>
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>AEGIS</RootNamespace>
     <AssemblyName>AEGIS.Core</AssemblyName>
     <Version>0.1.0</Version>

--- a/src/Numerics/Numerics.csproj
+++ b/src/Numerics/Numerics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>AEGIS.Numerics</AssemblyName>
     <RootNamespace>AEGIS.Numerics</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>

--- a/src/Storage.Hadoop/Storage.Hadoop.csproj
+++ b/src/Storage.Hadoop/Storage.Hadoop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>AEGIS.Storage.Hadoop</AssemblyName>
     <RootNamespace>AEGIS.Storage.Hadoop</RootNamespace>
     <CodeAnalysisRuleSet>..\analyzer.ruleset</CodeAnalysisRuleSet>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>AEGIS.Storage</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>
     <Version>0.1.0</Version>

--- a/src/Tests.Collections/Tests.Collections.csproj
+++ b/src/Tests.Collections/Tests.Collections.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AEGIS.Tests.Collections</AssemblyName>
     <RootNamespace>AEGIS.Tests.Collections</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>

--- a/src/Tests.Core.Reference/Tests.Core.Reference.csproj
+++ b/src/Tests.Core.Reference/Tests.Core.Reference.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AEGIS.Tests.Core.Reference</AssemblyName>
     <RootNamespace>AEGIS.Tests.Core.Reference</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>

--- a/src/Tests.Core/Tests.Core.csproj
+++ b/src/Tests.Core/Tests.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AEGIS.Tests.Core</AssemblyName>
     <RootNamespace>AEGIS.Tests.Core</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>

--- a/src/Tests.Numerics/Tests.Numerics.csproj
+++ b/src/Tests.Numerics/Tests.Numerics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AEGIS.Tests.Numerics</AssemblyName>
     <RootNamespace>AEGIS.Tests.Numerics</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>

--- a/src/Tests.Storage.Hadoop/Tests.Storage.Hadoop.csproj
+++ b/src/Tests.Storage.Hadoop/Tests.Storage.Hadoop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>AEGIS.Tests.Storage.Hadoop</AssemblyName>
     <RootNamespace>AEGIS.Tests.Storage.Hadoop</RootNamespace>
     <Authors>Roberto Giachetta et al.</Authors>


### PR DESCRIPTION
Update library projects to .NET Standard 2.1 and test projects to .NET Core 3.1. (Versions with LTS support.)