### PR TITLE
Fix EPSG identifiers for IdentifiedObjects

### DIFF
--- a/src/Core.Reference/Collections/Formula/Projections/GuamProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/GuamProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Guam projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9831", "Guam Projection")]
+    [IdentifiedObject("EPSG::9831", "Guam Projection")]
     public class GuamProjection : CoordinateProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/KrovakModifiedNorthOrientedProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/KrovakModifiedNorthOrientedProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Krovak Modified North Oriented Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::1043", "Krovak Modified North Oriented Projection")]
+    [IdentifiedObject("EPSG::1043", "Krovak Modified North Oriented Projection")]
     public class KrovakModifiedNorthOrientedProjection : KrovakModifiedProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/KrovakModifiedProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/KrovakModifiedProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Krovak Modified Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::1042", "Krovak Modified Projection")]
+    [IdentifiedObject("EPSG::1042", "Krovak Modified Projection")]
     public class KrovakModifiedProjection : KrovakProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/KrovakNorthOrientedProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/KrovakNorthOrientedProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Krovak North Oriented Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::1041", "Krovak North Oriented Projection")]
+    [IdentifiedObject("EPSG::1041", "Krovak North Oriented Projection")]
     public class KrovakNorthOrientedProjection : KrovakProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/KrovakProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/KrovakProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Krovak Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9819", "Krovak Projection")]
+    [IdentifiedObject("EPSG::9819", "Krovak Projection")]
     public class KrovakProjection : CoordinateProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/LambertAzimuthalEqualAreaProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/LambertAzimuthalEqualAreaProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Lambert Azimuthal Equal Area Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9820", "Lambert Azimuthal Equal Area Projection")]
+    [IdentifiedObject("EPSG::9820", "Lambert Azimuthal Equal Area Projection")]
     public class LambertAzimuthalEqualAreaProjection : CoordinateProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/LambertAzimuthalEqualAreaSphericalProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/LambertAzimuthalEqualAreaSphericalProjection.cs
@@ -20,7 +20,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Lambert Azimuthal Equal Area Spherical Projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::1027", "Lambert Azimuthal Equal Area (Spherical) Projection")]
+    [IdentifiedObject("EPSG::1027", "Lambert Azimuthal Equal Area (Spherical) Projection")]
     public class LambertAzimuthalEqualAreaSphericalProjection : LambertAzimuthalEqualAreaProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/LambertConicConformal1SPWestOrientatedProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/LambertConicConformal1SPWestOrientatedProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Lambert Conic Conformal (1SP West Orientated) projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9826", "Lambert Conic Conformal (West Orientated)")]
+    [IdentifiedObject("EPSG::9826", "Lambert Conic Conformal (West Orientated)")]
     public class LambertConicConformal1SPWestOrientatedProjection : LambertConicConformal1SPProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/LambertConicConformal2SPBelgiumProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/LambertConicConformal2SPBelgiumProjection.cs
@@ -20,7 +20,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Lambert Conic Conformal (2SP Belgium) projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9803", "Lambert Conic Conformal (2SP Belgium)")]
+    [IdentifiedObject("EPSG::9803", "Lambert Conic Conformal (2SP Belgium)")]
     public class LambertConicConformal2SPBelgiumProjection : LambertConicConformal2SPProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Projections/ModifiedAzimuthalEquidistantProjection.cs
+++ b/src/Core.Reference/Collections/Formula/Projections/ModifiedAzimuthalEquidistantProjection.cs
@@ -21,7 +21,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a Modified Azimuthal Equidistant projection.
     /// </summary>
-    [IdentifiedObject("AEGIS::9832", "Modified Azimuthal Equidistant Projection")]
+    [IdentifiedObject("EPSG::9832", "Modified Azimuthal Equidistant Projection")]
     public class ModifiedAzimuthalEquidistantProjection : CoordinateProjection
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Transformations/P6LeftHandedSeismicBinGridTransformation.cs
+++ b/src/Core.Reference/Collections/Formula/Transformations/P6LeftHandedSeismicBinGridTransformation.cs
@@ -20,7 +20,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a P6 left handed seismic bin grid transformation.
     /// </summary>
-    [IdentifiedObject("AEGIS::1049", "P6 (I = J-90°) seismic bin grid transformation")]
+    [IdentifiedObject("EPSG::1049", "P6 (I = J-90°) seismic bin grid transformation")]
     public class P6LeftHandedSeismicBinGridTransformation : P6SeismicBinGridTransformation
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Transformations/P6RightHandedSeismicBinGridTransformation.cs
+++ b/src/Core.Reference/Collections/Formula/Transformations/P6RightHandedSeismicBinGridTransformation.cs
@@ -20,7 +20,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a P6 right handed seismic bin grid transformation.
     /// </summary>
-    [IdentifiedObject("AEGIS::9666", "P6 (I = J+90°) seismic bin grid transformation")]
+    [IdentifiedObject("EPSG::9666", "P6 (I = J+90°) seismic bin grid transformation")]
     public class P6RightHandedSeismicBinGridTransformation : P6SeismicBinGridTransformation
     {
         /// <summary>

--- a/src/Core.Reference/Collections/Formula/Transformations/SimilarityTransformation.cs
+++ b/src/Core.Reference/Collections/Formula/Transformations/SimilarityTransformation.cs
@@ -20,7 +20,7 @@ namespace AEGIS.Reference.Collections.Formula
     /// <summary>
     /// Represents a similarity transformation.
     /// </summary>
-    [IdentifiedObject("AEGIS::9621", "Similarity Transformation")]
+    [IdentifiedObject("EPSG::9621", "Similarity Transformation")]
     public class SimilarityTransformation : CoordinateTransformation<Coordinate>
     {
         /// <summary>


### PR DESCRIPTION
Fix the inconsistency between `CoordinateOperationMethods` and the specific classes in the EPSG codes. Some of them are incorrectly prefixed with `AEGIS::` instead of `EPSG::`.